### PR TITLE
Updated menu, added reassign feature, view + add work logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ For example, the provided `labelFormat` will appear like this:
 "jiraSearch.updateInterval" : 5
 ```
 
+#### Enable Worklogs
+
+Worklog support is an experimental feature that could use a tester. It is disabled by default.
+
+When enabled (set this option to `true`) you can view and add worklogs to an issue.
+
+This feature does _not_ work properly with third party time tracking plugins such as Tempo.
+
+```
+"jiraSearch.enableWorklogs: false
+```
+
 ## Known Issues
 
 Issues will not get pulled everytime you run the command, they will only get pulled when you run the command the first time and then they will be pulled every X interval (default 5 minutes) which is customizable.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ Issues will not get pulled everytime you run the command, they will only get pul
 
 ## Release Notes
 
+### 0.3.0
+
+* Added experimental worklog support (add and view worklogs!)
+* Changed the task menu to a quickpick so you no longer need a mouse
+* Change the assignee of an issue
+* Added placeholders to quickpick menus to make things a little more user-friendly
+* Added missing timeouts to status bar updates
+* Return to menu after transitioning issues, viewing comments, etc.
+
+### 0.2.0 
+
+* Automatically register configuration options
+* New command to look up an issue by key ("Jira View Issue")
+* Return to the menu after closing the comment list 
+* Option to return to the menu if no comments are found
 
 ### 0.1.0
 

--- a/package.json
+++ b/package.json
@@ -80,6 +80,11 @@
           "type": "number",
           "default": 5,
           "description": "How often to update local issue cache (in minutes)"
+        },
+        "jiraSearch.enableWorklogs": {
+          "type": "boolean",
+          "default": false,
+          "description": "Experimental: View and add worklogs. Does not work with third party plugins such as Tempo."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "displayName": "jira-search",
   "description": "Allows you to view your jira issues in visual studio code.",
-  "version": "0.1.1",
+  "version": "0.3.0",
   "publisher": "xceleration",
   "engines": {
     "vscode": "^1.5.0"

--- a/src/api/jira.ts
+++ b/src/api/jira.ts
@@ -110,6 +110,29 @@ export function getIssue(issueKey: string) {
       .catch(response => reject(response));
   });
 }
+
+export function getPossibleAssigneesForIssue(issueKey: string) {
+  return new Promise((resolve, reject) => {
+    _invoke(`/api/latest/user/permission/search?permissions=ASSIGNABLE_USER&issueKey=${issueKey}`, 'GET')
+      .then(response => {
+        resolve(response);
+      })
+      .catch(err => reject(err));
+  });
+}
+
+export function setAssigneeForIssue(issueKey: string, username: string) {
+  return new Promise((resolve, reject) => {
+    _invoke(`/api/latest/issue/${issueKey}/assignee`, 'PUT', { name: username })
+      .then(response => {
+        resolve(response);
+      })
+      .catch(err => {
+        resolve(err);
+      });
+  });
+}
+
 export function setConfig(baseUrl: string, username: string, password: string) {
   _config.baseUrl = baseUrl;
   _config.username = username;

--- a/src/api/jira.ts
+++ b/src/api/jira.ts
@@ -133,6 +133,33 @@ export function setAssigneeForIssue(issueKey: string, username: string) {
   });
 }
 
+export function getWorklogsForIssue(issueKey: string) {
+  return new Promise((resolve, reject) => {
+    _invoke(`/api/latest/issue/${issueKey}/worklog`, 'GET')
+      .then((response: any) => {
+        resolve(response);
+      })
+      .catch((err: any) => {
+        resolve(err);
+      });
+  });
+}
+
+export function addWorklogToIssue(issueKey: string, comment: string, timeSpentSeconds: number) {
+  return new Promise((resolve, reject) => {
+    _invoke(`/api/latest/issue/${issueKey}/worklog`, 'POST', {
+      comment: comment,
+      timeSpentSeconds: timeSpentSeconds
+    })
+      .then((response: any) => {
+        resolve(response);
+      })
+      .catch((err: any) => {
+        resolve(err);
+      });
+  });
+}
+
 export function setConfig(baseUrl: string, username: string, password: string) {
   _config.baseUrl = baseUrl;
   _config.username = username;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,27 +1,28 @@
-import {workspace} from 'vscode';
+import { workspace } from 'vscode';
 const defaultConfig = {
-    url : "",
-    username : "",
-    password : "",
-    //how to display each issue
-    labelFormat : "{fields.status.name} - [{fields.issuetype.name}][{fields.priority.name}] {key}",
-    descriptionFormat : "{fields.summary}", 
-    detailFormat : "{fields.description}",
-    //data to copy
-    clipboardFormat: "{key} - {fields.summary} - {fields.description}",
-    updateFormat: "{key} - {field.summary}",
-    //jql (Jira Query Language) query format (only token available is username currently)
-    //currently will give all issues assigned to you, where status is not done, and it will be ordered by created date.
-    jql: "assignee={username} and status!=Done order by created",
-    //how often to update (in minutes)
-    updateInterval : 5
-}
+  url: '',
+  username: '',
+  password: '',
+  //how to display each issue
+  labelFormat: '{fields.status.name} - [{fields.issuetype.name}][{fields.priority.name}] {key}',
+  descriptionFormat: '{fields.summary}',
+  detailFormat: '{fields.description}',
+  //data to copy
+  clipboardFormat: '{key} - {fields.summary} - {fields.description}',
+  updateFormat: '{key} - {field.summary}',
+  //jql (Jira Query Language) query format (only token available is username currently)
+  //currently will give all issues assigned to you, where status is not done, and it will be ordered by created date.
+  jql: 'assignee={username} and status!=Done order by created',
+  //how often to update (in minutes)
+  updateInterval: 5,
+  enableWorklogs: false
+};
 let jiraConfig = Object.assign({}, defaultConfig);
 
-export default function getConfiguration(){
-    let config = workspace.getConfiguration("jiraSearch");
-    for(var field in defaultConfig){
-        jiraConfig[field] = config.get(field, defaultConfig[field]);
-    }
-    return jiraConfig;
+export default function getConfiguration() {
+  let config = workspace.getConfiguration('jiraSearch');
+  for (var field in defaultConfig) {
+    jiraConfig[field] = config.get(field, defaultConfig[field]);
+  }
+  return jiraConfig;
 }

--- a/src/jira.ts
+++ b/src/jira.ts
@@ -158,6 +158,7 @@ function addComment(issue): void {
   };
   window.showInputBox(inputBoxOptions).then(comment => {
     jiraApi.addComment(issue.key, comment).then(() => {
+      showSelectionOptions({ label: parseIssueLabelTokens(issue) });
       window.setStatusBarMessage(`Successfully added comment to JIRA ${label}`);
     });
   });
@@ -183,11 +184,13 @@ function showTransitionOptions(issue): void {
           var newTransition = transitions.filter(transition => transition.name == transitionName)[0];
           jiraApi.setTransition(issue.key, newTransition.id).then(() => {
             jiraUpdate().then(() => {
-              window.setStatusBarMessage(`Successfully transitioned JIRA ${label} to [${transitionName}]`);
+              window.setStatusBarMessage(`Successfully transitioned JIRA ${label} to [${transitionName}]`, 5000);
+              showSelectionOptions({ label: parseIssueLabelTokens(issue) });
             });
           });
         } else {
-          window.setStatusBarMessage(`JIRA ${label} is already in status [${transitionName}]`);
+          window.setStatusBarMessage(`JIRA ${label} is already in status [${transitionName}]`, 5000);
+          showSelectionOptions({ label: parseIssueLabelTokens(issue) });
         }
       });
   });
@@ -213,10 +216,12 @@ function showReassignOptions(issue: any): void {
       jiraApi
         .setAssigneeForIssue(issue.key, assigneeKey)
         .then(() => {
-          window.setStatusBarMessage(`Reassigned ${issue.key} to ${selectedAssignee}`);
+          window.setStatusBarMessage(`Reassigned ${issue.key} to ${selectedAssignee}`, 5000);
+          showSelectionOptions({ label: parseIssueLabelTokens(issue) });
         })
         .catch(err => {
-          window.setStatusBarMessage(`Could not reassign ${issue.key} to ${selectedAssignee}`);
+          window.setStatusBarMessage(`Could not reassign ${issue.key} to ${selectedAssignee}`, 5000);
+          showSelectionOptions({ label: parseIssueLabelTokens(issue) });
         });
     });
   });

--- a/src/jira.ts
+++ b/src/jira.ts
@@ -282,15 +282,12 @@ function showSelectionOptions(quickPickItem: any): void {
     title: 'Cancel'
   };
 
-  let selectOptions: string[] = [
-    'Copy to Clipboard',
-    'Add Comment',
-    'View Comments',
-    'Reassign',
-    'Transition',
-    'Add Worklog',
-    'View Worklogs'
-  ];
+  let selectOptions: string[] = ['Copy to Clipboard', 'Add Comment', 'View Comments', 'Reassign', 'Transition'];
+
+  if (jiraConfig.enableWorklogs === true) {
+    selectOptions.push('Add Worklog', 'View Worklogs');
+  }
+
   window
     .showQuickPick(selectOptions, {
       placeHolder: `Perform Which Action on ${quickPickItem.label}?`
@@ -315,7 +312,7 @@ function showSelectionOptions(quickPickItem: any): void {
         case 'Add Worklog':
           addWorklog(selectedIssue);
           break;
-        case 'Show Worklogs':
+        case 'View Worklogs':
           showWorklogs(selectedIssue);
           break;
         default:

--- a/src/jira.ts
+++ b/src/jira.ts
@@ -191,6 +191,33 @@ function showTransitionOptions(issue): void {
       });
   });
 }
+
+function showReassignOptions(issue: any): void {
+  let label = parseIssueLabelTokens(issue);
+
+  jiraApi.getPossibleAssigneesForIssue(issue.key).then((response: Array<any>) => {
+    let assignees = {};
+    let assigneeList = [];
+
+    for (let assignee of response) {
+      assignees[assignee.displayName] = assignee;
+      assigneeList.push(assignee.displayName);
+    }
+
+    window.showQuickPick(assigneeList).then(selectedAssignee => {
+      let assigneeKey = assignees[selectedAssignee].key;
+      jiraApi
+        .setAssigneeForIssue(issue.key, assigneeKey)
+        .then(() => {
+          window.setStatusBarMessage(`Reassigned ${issue.key} to ${selectedAssignee}`);
+        })
+        .catch(err => {
+          window.setStatusBarMessage(`Could not reassign ${issue.key} to ${selectedAssignee}`);
+        });
+    });
+  });
+}
+
 /**
  * 
  * @param {*} quickPickItem Contains "label" which should be the issue key
@@ -208,6 +235,7 @@ function showSelectionOptions(quickPickItem: any): void {
       { title: 'Copy' },
       { title: 'Add Comment' },
       { title: 'View Comments' },
+      { title: 'Reassign' },
       { title: 'Transition' }
     )
     .then(result => {
@@ -221,9 +249,12 @@ function showSelectionOptions(quickPickItem: any): void {
         case 'Add Comment':
           addComment(selectedIssue);
           break;
-        case 'Transition': {
+        case 'Transition':
           showTransitionOptions(selectedIssue);
-        }
+          break;
+        case 'Reassign':
+          showReassignOptions(selectedIssue);
+          break;
         default:
           break;
       }

--- a/src/jira.ts
+++ b/src/jira.ts
@@ -175,7 +175,8 @@ function showTransitionOptions(issue): void {
             name = '[current] ' + name;
           }
           return name;
-        })
+        }),
+        { placeHolder: `Transition ${issue.key} from ${currentTransition} to...` }
       )
       .then(transitionName => {
         if (transitionName !== currentTransition) {
@@ -204,7 +205,10 @@ function showReassignOptions(issue: any): void {
       assigneeList.push(assignee.displayName);
     }
 
-    window.showQuickPick(assigneeList).then(selectedAssignee => {
+    let currentAssignee: string = issue.fields.assignee === null ? 'Unassigned' : issue.fields.assignee.displayName;
+    let label: string = `Change assignee from ${currentAssignee} to...`;
+
+    window.showQuickPick(assigneeList, { placeHolder: label }).then(selectedAssignee => {
       let assigneeKey = assignees[selectedAssignee].key;
       jiraApi
         .setAssigneeForIssue(issue.key, assigneeKey)
@@ -228,19 +232,14 @@ function showSelectionOptions(quickPickItem: any): void {
     isCloseAffordance: true,
     title: 'Cancel'
   };
+
   window
-    .showInformationMessage(
-      `Perform Which Action on ${quickPickItem.label}?`,
-      cancelButton,
-      { title: 'Copy' },
-      { title: 'Add Comment' },
-      { title: 'View Comments' },
-      { title: 'Reassign' },
-      { title: 'Transition' }
-    )
-    .then(result => {
-      switch (result.title) {
-        case 'Copy':
+    .showQuickPick(['Copy to Clipboard', 'Add Comment', 'View Comments', 'Reassign', 'Transition'], {
+      placeHolder: `Perform Which Action on ${quickPickItem.label}?`
+    })
+    .then((selection: string) => {
+      switch (selection) {
+        case 'Copy to Clipboard':
           copyIssueToClipboard(selectedIssue);
           break;
         case 'View Comments':
@@ -264,7 +263,9 @@ export function showIssues() {
   if (jiraQuickPicks.length === 0) {
     jiraUpdate().then(showIssues);
   } else {
-    window.showQuickPick(jiraQuickPicks, jiraQuickPickOptions).then(showSelectionOptions);
+    window
+      .showQuickPick(jiraQuickPicks, Object.assign(jiraQuickPickOptions, { placeHolder: 'Select an issue' }))
+      .then(showSelectionOptions);
   }
 }
 


### PR DESCRIPTION
* Added experimental worklog support (add and view worklogs!)
* Changed the task menu to a quickpick so you no longer need a mouse
* Change the assignee of an issue
* Added placeholders to quickpick menus to make things a little more user-friendly
* Added missing timeouts to status bar updates
* Return to menu after transitioning issues, viewing comments, etc.